### PR TITLE
Some working skeletal mesh in UE5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ And a second issue that cause animations to fail, this bug is fixed here.
 
 See a sample on how to use it to create a procedural skeletal mesh and bones here: https://github.com/Fransferdy/creaturecreator/tree/main
 
-# Runtime Skeletal Mesh Generator for UE5.1
+# Runtime Skeletal Mesh Generator for UE5.1 ( does not currently work with Unreal 5.2+)
 Helper to create a SkeletalMeshComponent in UE5.1 at runtime.
 
-This is a UE4 plugin that simplify the process of creating a `USkeletalMeshComponent`, with many surfaces, at runtime.
+This is a UE5 plugin that simplify the process of creating a `USkeletalMeshComponent`, with many surfaces, at runtime.
 You can just pass all the surfaces' data, this library will take care to correctly populate the UE4 buffers, needed to have a fully working `USkeletalMeshComponent`.
 
 ## How to use it

--- a/Source/RuntimeSkeletalMeshGenerator/RuntimeSkeletalMeshGenerator.cpp
+++ b/Source/RuntimeSkeletalMeshGenerator/RuntimeSkeletalMeshGenerator.cpp
@@ -14,6 +14,10 @@
 
 #include "Rendering/SkeletalMeshLODModel.h"
 #include "Rendering/SkeletalMeshModel.h"
+#include <algorithm> 
+
+#include "Engine/SkeletalMesh.h"
+#include "Materials/MaterialInstance.h"
 #include "Engine/SkinnedAssetCommon.h"
 #include "Engine/SkeletalMeshLODSettings.h"
 #include "Engine/SkinnedAssetAsyncCompileUtils.h"
@@ -149,12 +153,14 @@ void FRuntimeSkeletalMeshGenerator::GenerateSkeletalMesh(
 	}
 	check(ImportedModelData.PointToRawMap.Num() == Vertices.Num());
 
+
 	for (int32 I = 0; I < Surfaces.Num(); I++)
 	{
 		SkeletalMeshImportData::FMaterial& Mat = ImportedModelData.Materials.AddDefaulted_GetRef();
 		Mat.Material = SurfacesMaterial[I];
 		Mat.MaterialImportName = SurfacesMaterial[I]->GetFullName();
 	}
+
 
 	ImportedModelData.Faces.SetNum(Indices.Num() / 3);
 	for (int32 FaceIndex = 0; FaceIndex < ImportedModelData.Faces.Num(); FaceIndex += 1)
@@ -287,8 +293,6 @@ void FRuntimeSkeletalMeshGenerator::GenerateSkeletalMesh(
 	ImportedModelData.bHasVertexColors = Surfaces[0].Colors.Num() > 0;;
 	ImportedModelData.bHasNormals = true;
 	ImportedModelData.bHasTangents = true;
-	ImportedModelData.bUseT0AsRefPose = false;
-	ImportedModelData.bDiffPose = false;
 #endif
 
 	LODMeshRenderData->RenderSections.SetNum(Surfaces.Num());
@@ -545,9 +549,8 @@ void FRuntimeSkeletalMeshGenerator::GenerateSkeletalMesh(
 	{
 		SkeletalMesh->GetMaterials().Add(Material);
 	}
-
-	// Rebuild inverse ref pose matrices.
 #if WITH_EDITOR
+	// Rebuild inverse ref pose matrices.
 	SkeletalMesh->SkelMirrorTable.Empty();
 	SkeletalMesh->SkelMirrorAxis = EAxis::Type::None;
 	SkeletalMesh->SkelMirrorFlipAxis = EAxis::Type::None;
@@ -567,6 +570,10 @@ void FRuntimeSkeletalMeshGenerator::GenerateSkeletalMesh(
 		USkeletalMeshLODSettings* NewLODSettings = NewObject<USkeletalMeshLODSettings>(SkeletalMesh);
 		SkeletalMesh->SetLODSettings(NewLODSettings);
 	}
+
+#if WITH_EDITOR
+	const FSkeletalMeshLODGroupSettings* SkeletalMeshLODGroupSettings = SkeletalMesh->GetLODSettings() != nullptr ? &SkeletalMesh->GetLODSettings()->GetSettingsForLODLevel(LODIndex) : nullptr;
+	MeshLodInfo.BuildGUID = MeshLodInfo.ComputeDeriveDataCacheKey(SkeletalMeshLODGroupSettings);
 	if (SkeletalMesh->GetLODSettings() != nullptr)
 	{
 		// update mapping information on the class
@@ -576,11 +583,10 @@ void FRuntimeSkeletalMeshGenerator::GenerateSkeletalMesh(
 
 		const int32 NumSettings = FMath::Min(SkeletalMesh->GetLODSettings()->GetNumberOfSettings(), SkeletalMesh->GetLODNum());
 		checkf(LODIndex < NumSettings, TEXT("Make sure the LODSettings are set for the LODIndex 0."));
+
+		//const FSkeletalMeshLODGroupSettings* SkeletalMeshLODGroupSettings = &SkeletalMesh->GetLODSettings()->GetSettingsForLODLevel(LODIndex);
+		//MeshLodInfo.BuildGUID = MeshLodInfo.ComputeDeriveDataCacheKey(SkeletalMeshLODGroupSettings);
 	}
-	
-#if WITH_EDITOR
-	const FSkeletalMeshLODGroupSettings* SkeletalMeshLODGroupSettings = SkeletalMesh->GetLODSettings() != nullptr ? &SkeletalMesh->GetLODSettings()->GetSettingsForLODLevel(LODIndex) : nullptr;
-	MeshLodInfo.BuildGUID = MeshLodInfo.ComputeDeriveDataCacheKey(SkeletalMeshLODGroupSettings);
 
 	const FString BuildStringID = SkeletalMesh->GetImportedModel()->LODModels[0].GetLODModelDeriveDataKey();
 	SkeletalMesh->GetImportedModel()->LODModels[0].BuildStringID = BuildStringID;
@@ -588,13 +594,8 @@ void FRuntimeSkeletalMeshGenerator::GenerateSkeletalMesh(
 	SkeletalMesh->SetLODImportedDataVersions(0, ESkeletalMeshGeoImportVersions::LatestVersion, ESkeletalMeshSkinningImportVersions::LatestVersion);
 	SkeletalMesh->SaveLODImportedData(0, ImportedModelData);
 	SkeletalMesh->InvalidateDeriveDataCacheGUID();
-
-	SkeletalMesh->SetLODImportedDataVersions(0, ESkeletalMeshGeoImportVersions::LatestVersion, ESkeletalMeshSkinningImportVersions::LatestVersion);
-	SkeletalMesh->SetUseLegacyMeshDerivedDataKey(false);
+//	SkeletalMesh->SetUseLegacyMeshDerivedDataKey(false);
 #endif
-
-	// SkeletalMesh->GetReductionSettings(0);
-	// SkeletalMesh->
 
 	// Calls InitResources.
 	SkeletalMesh->PostLoad();
@@ -605,40 +606,14 @@ void FRuntimeSkeletalMeshGenerator::GenerateSkeletalMesh(
 	// if you don't set this random crashes occur.
 
 	// Begin build
-	FSkinnedAssetBuildContext Context;
-	Context.RecreateRenderStateContext = MakeUnique<FSkinnedMeshComponentRecreateRenderStateContext>(SkeletalMesh, false);
-	SkeletalMesh->ReleaseResources();
-	SkeletalMesh->ReleaseResourcesFence.Wait();
 
-	// Build
-	SkeletalMesh->AllocateResourceForRendering();
-	// Maybe will have to use it ???
-	//InternalSkeletalMeshHelper::RestoreLodMaterialMapBackup(this, BackupSectionsPerLOD);
-	
-	// Maybe will have to use this too ???
-	SkeletalMesh->GetSamplingInfoInternal().BuildRegions(SkeletalMesh);
-	SkeletalMesh->GetSamplingInfoInternal().BuildWholeMesh(SkeletalMesh);
-	//
 	SkeletalMesh->UpdateUVChannelData(true);
 	SkeletalMesh->UpdateGenerateUpToData();
-	
-	// End build
-	SkeletalMesh->ApplyFinishBuildInternalData(&Context);
-	
-	// Note: meshes can be built during automated importing.  We should not create resources in that case
-	// as they will never be released when this object is deleted
-	
-	// Reinitialize the static mesh's resources.
-	SkeletalMesh->InitResources();
-	
-	SkeletalMesh->OnPostMeshCached().Broadcast(SkeletalMesh);
-	
-	//SkeletalMesh->Build();
-	
+	SkeletalMesh->Build();
+
 	SkeletalMesh->GetOnMeshChanged().Broadcast();
-	
-	//SkeletalMesh->PostEditChange();
-	
+
+	SkeletalMesh->PostEditChange();
 #endif
 }
 
@@ -690,43 +665,31 @@ USkeletalMeshComponent* FRuntimeSkeletalMeshGenerator::GenerateSkeletalMeshCompo
 	return SkeletalMeshComponent;
 }
 
-USkeletalMesh* FRuntimeSkeletalMeshGenerator::UpdateSkeletalMeshComponent(
+void FRuntimeSkeletalMeshGenerator::UpdateSkeletalMeshComponent(
 	USkeletalMeshComponent* SkeletalMeshComponent,
 	USkeleton* BaseSkeleton,
 	const TArray<FMeshSurface>& Surfaces,
 	const TArray<UMaterialInterface*>& SurfacesMaterial,
 	const TMap<FName, FTransform>& BoneTransformOverrides)
 {
-	USkeletalMesh* SourceSkeletalMesh = SkeletalMeshComponent->GetSkeletalMeshAsset();
-	USkeletalMeshLODSettings* SourceLODSettings = SourceSkeletalMesh->GetLODSettings();
-
 	// Note: we do not pass anything so the skeletal mesh is transient and
 	// destroyed when the play session end.
-	USkeletalMesh* NewSkeletalMesh = NewObject<USkeletalMesh>();
-	//USkeletalMeshLODSettings* NewLODSettings = DuplicateObject(SourceLODSettings, NewSkeletalMesh);
-	
-	NewSkeletalMesh->SetRefSkeleton(BaseSkeleton->GetReferenceSkeleton());
-	NewSkeletalMesh->SetSkeleton(BaseSkeleton);
-	//NewSkeletalMesh->SetLODSettings(NewLODSettings);
+	USkeletalMesh* SkeletalMesh = NewObject<USkeletalMesh>();
+	SkeletalMesh->SetRefSkeleton(BaseSkeleton->GetReferenceSkeleton());
+	SkeletalMesh->SetSkeleton(BaseSkeleton);
 
 	GenerateSkeletalMesh(
-		NewSkeletalMesh,
+		SkeletalMesh,
 		Surfaces,
 		SurfacesMaterial,
 		BoneTransformOverrides);
-	
+
 	// We register the skeleton resource (which is not meant to be transient to
 	// the engine).
-	SkeletalMeshComponent->bPauseAnims = true;
-	SkeletalMeshComponent->SetSkeletalMesh(NewSkeletalMesh, false);
-	//SkeletalMeshComponent->RefreshExternalMorphTargetWeights(true);
-
-	SkeletalMeshComponent->bPauseAnims = false;
+	SkeletalMeshComponent->SetSkeletalMesh(SkeletalMesh);
 
 	check(SkeletalMeshComponent->RequiredBones.Num() != 0);
 	check(SkeletalMeshComponent->FillComponentSpaceTransformsRequiredBones.Num() != 0);
-
-	return NewSkeletalMesh;
 }
 
 bool FRuntimeSkeletalMeshGenerator::DecomposeSkeletalMesh(
@@ -815,12 +778,7 @@ bool FRuntimeSkeletalMeshGenerator::DecomposeSkeletalMesh(
 				BoneInfluenceIndex < RenderSection.MaxBoneInfluences;
 				BoneInfluenceIndex += 1)
 			{
-				const int32 BoneIndex = RenderData.SkinWeightVertexBuffer.GetBoneIndex(VertexIndex, BoneInfluenceIndex);
 				Surface.BoneInfluences[i][BoneInfluenceIndex].VertexIndex = i;
-				if (!RenderSection.BoneMap.IsValidIndex(BoneIndex))
-				{
-					continue;
-				}
 				Surface.BoneInfluences[i][BoneInfluenceIndex].BoneIndex =
 					RenderSection.BoneMap[RenderData.SkinWeightVertexBuffer.GetBoneIndex(VertexIndex, BoneInfluenceIndex)];
 				Surface.BoneInfluences[i][BoneInfluenceIndex].Weight =

--- a/Source/RuntimeSkeletalMeshGenerator/RuntimeSkeletalMeshGenerator.cpp
+++ b/Source/RuntimeSkeletalMeshGenerator/RuntimeSkeletalMeshGenerator.cpp
@@ -14,7 +14,9 @@
 
 #include "Rendering/SkeletalMeshLODModel.h"
 #include "Rendering/SkeletalMeshModel.h"
-#include <algorithm> 
+#include "Engine/SkinnedAssetCommon.h"
+#include "Engine/SkeletalMeshLODSettings.h"
+#include "Engine/SkinnedAssetAsyncCompileUtils.h"
 
 void FRuntimeSkeletalMeshGeneratorModule::StartupModule()
 {
@@ -201,7 +203,7 @@ void FRuntimeSkeletalMeshGenerator::GenerateSkeletalMesh(
 			const int32 VertexIndex = Indices[WedgeIndex];
 
 			ImportedModelData.Wedges[WedgeIndex].VertexIndex = VertexIndex;
-			for (int32 UVIndex = 0; UVIndex < FMath::Min(MAX_TEXCOORDS, MAX_STATIC_TEXCOORDS); UVIndex += 1)
+			for (int32 UVIndex = 0; UVIndex < FMath::Min(static_cast<uint8>(MAX_TEXCOORDS), static_cast<uint8>(MAX_STATIC_TEXCOORDS)); UVIndex += 1)
 			{
 				ImportedModelData.Wedges[WedgeIndex].UVs[UVIndex] = StaticVertices[VertexIndex].UVs[UVIndex];
 			}
@@ -212,7 +214,7 @@ void FRuntimeSkeletalMeshGenerator::GenerateSkeletalMesh(
 	}
 
 	{
-		const int32 BoneNum = SkeletalMesh->Skeleton->GetReferenceSkeleton().GetRawBoneNum();
+		const int32 BoneNum = SkeletalMesh->GetSkeleton()->GetReferenceSkeleton().GetRawBoneNum();
 		SkeletalMeshImportData::FBone DefaultBone;
 		DefaultBone.Name = FString(TEXT(""));
 		DefaultBone.Flags = 0;
@@ -523,7 +525,7 @@ void FRuntimeSkeletalMeshGenerator::GenerateSkeletalMesh(
 #endif
 	}
 
-	const int32 BoneNum = SkeletalMesh->Skeleton->GetReferenceSkeleton().GetNum();
+	const int32 BoneNum = SkeletalMesh->GetSkeleton()->GetReferenceSkeleton().GetNum();
 	for (int32 BoneIndex = 0; BoneIndex < BoneNum; BoneIndex++)
 	{
 #if WITH_EDITOR
@@ -554,9 +556,11 @@ void FRuntimeSkeletalMeshGenerator::GenerateSkeletalMesh(
 	}
 
 	// Rebuild inverse ref pose matrices.
+#if WITH_EDITOR
 	SkeletalMesh->SkelMirrorTable.Empty();
 	SkeletalMesh->SkelMirrorAxis = EAxis::Type::None;
 	SkeletalMesh->SkelMirrorFlipAxis = EAxis::Type::None;
+#endif
 	SkeletalMesh->GetRefBasesInvMatrix().Empty();
 	SkeletalMesh->CalculateInvRefMatrices(); 
 	MeshRenderData->bReadyForStreaming = false;
@@ -567,8 +571,11 @@ void FRuntimeSkeletalMeshGenerator::GenerateSkeletalMesh(
 	{
 		SkeletalMesh->NeverStream = false;
 	}
-
-#if WITH_EDITOR
+	if (SkeletalMesh->GetLODSettings() == nullptr)
+	{
+		USkeletalMeshLODSettings* NewLODSettings = NewObject<USkeletalMeshLODSettings>(SkeletalMesh);
+		SkeletalMesh->SetLODSettings(NewLODSettings);
+	}
 	if (SkeletalMesh->GetLODSettings() != nullptr)
 	{
 		// update mapping information on the class
@@ -578,10 +585,11 @@ void FRuntimeSkeletalMeshGenerator::GenerateSkeletalMesh(
 
 		const int32 NumSettings = FMath::Min(SkeletalMesh->GetLODSettings()->GetNumberOfSettings(), SkeletalMesh->GetLODNum());
 		checkf(LODIndex < NumSettings, TEXT("Make sure the LODSettings are set for the LODIndex 0."));
-
-		const FSkeletalMeshLODGroupSettings* SkeletalMeshLODGroupSettings = &SkeletalMesh->GetLODSettings()->GetSettingsForLODLevel(LODIndex);
-		MeshLodInfo.BuildGUID = MeshLodInfo.ComputeDeriveDataCacheKey(SkeletalMeshLODGroupSettings);
 	}
+	
+#if WITH_EDITOR
+	const FSkeletalMeshLODGroupSettings* SkeletalMeshLODGroupSettings = SkeletalMesh->GetLODSettings() != nullptr ? &SkeletalMesh->GetLODSettings()->GetSettingsForLODLevel(LODIndex) : nullptr;
+	MeshLodInfo.BuildGUID = MeshLodInfo.ComputeDeriveDataCacheKey(SkeletalMeshLODGroupSettings);
 
 	const FString BuildStringID = SkeletalMesh->GetImportedModel()->LODModels[0].GetLODModelDeriveDataKey();
 	SkeletalMesh->GetImportedModel()->LODModels[0].BuildStringID = BuildStringID;
@@ -589,7 +597,13 @@ void FRuntimeSkeletalMeshGenerator::GenerateSkeletalMesh(
 	SkeletalMesh->SetLODImportedDataVersions(0, ESkeletalMeshGeoImportVersions::LatestVersion, ESkeletalMeshSkinningImportVersions::LatestVersion);
 	SkeletalMesh->SaveLODImportedData(0, ImportedModelData);
 	SkeletalMesh->InvalidateDeriveDataCacheGUID();
+
+	SkeletalMesh->SetLODImportedDataVersions(0, ESkeletalMeshGeoImportVersions::LatestVersion, ESkeletalMeshSkinningImportVersions::LatestVersion);
+	SkeletalMesh->SetUseLegacyMeshDerivedDataKey(false);
 #endif
+
+	// SkeletalMesh->GetReductionSettings(0);
+	// SkeletalMesh->
 
 	// Calls InitResources.
 	SkeletalMesh->PostLoad();
@@ -598,7 +612,42 @@ void FRuntimeSkeletalMeshGenerator::GenerateSkeletalMesh(
 	// Signals to editor we are done with our changes
 	// This is to prevent the editor variable changes overwriting the import mesh,
 	// if you don't set this random crashes occur.
-	SkeletalMesh->StackPostEditChange();
+
+	// Begin build
+	FSkinnedAssetBuildContext Context;
+	Context.RecreateRenderStateContext = MakeUnique<FSkinnedMeshComponentRecreateRenderStateContext>(SkeletalMesh, false);
+	SkeletalMesh->ReleaseResources();
+	SkeletalMesh->ReleaseResourcesFence.Wait();
+
+	// Build
+	SkeletalMesh->AllocateResourceForRendering();
+	// Maybe will have to use it ???
+	//InternalSkeletalMeshHelper::RestoreLodMaterialMapBackup(this, BackupSectionsPerLOD);
+	
+	// Maybe will have to use this too ???
+	SkeletalMesh->GetSamplingInfoInternal().BuildRegions(SkeletalMesh);
+	SkeletalMesh->GetSamplingInfoInternal().BuildWholeMesh(SkeletalMesh);
+	//
+	SkeletalMesh->UpdateUVChannelData(true);
+	SkeletalMesh->UpdateGenerateUpToData();
+	
+	// End build
+	SkeletalMesh->ApplyFinishBuildInternalData(&Context);
+	
+	// Note: meshes can be built during automated importing.  We should not create resources in that case
+	// as they will never be released when this object is deleted
+	
+	// Reinitialize the static mesh's resources.
+	SkeletalMesh->InitResources();
+	
+	SkeletalMesh->OnPostMeshCached().Broadcast(SkeletalMesh);
+	
+	//SkeletalMesh->Build();
+	
+	SkeletalMesh->GetOnMeshChanged().Broadcast();
+	
+	//SkeletalMesh->PostEditChange();
+	
 #endif
 }
 
@@ -650,31 +699,43 @@ USkeletalMeshComponent* FRuntimeSkeletalMeshGenerator::GenerateSkeletalMeshCompo
 	return SkeletalMeshComponent;
 }
 
-void FRuntimeSkeletalMeshGenerator::UpdateSkeletalMeshComponent(
+USkeletalMesh* FRuntimeSkeletalMeshGenerator::UpdateSkeletalMeshComponent(
 	USkeletalMeshComponent* SkeletalMeshComponent,
 	USkeleton* BaseSkeleton,
 	const TArray<FMeshSurface>& Surfaces,
 	const TArray<UMaterialInterface*>& SurfacesMaterial,
 	const TMap<FName, FTransform>& BoneTransformOverrides)
 {
+	USkeletalMesh* SourceSkeletalMesh = SkeletalMeshComponent->GetSkeletalMeshAsset();
+	USkeletalMeshLODSettings* SourceLODSettings = SourceSkeletalMesh->GetLODSettings();
+
 	// Note: we do not pass anything so the skeletal mesh is transient and
 	// destroyed when the play session end.
-	USkeletalMesh* SkeletalMesh = NewObject<USkeletalMesh>();
-	SkeletalMesh->SetRefSkeleton(BaseSkeleton->GetReferenceSkeleton());
-	SkeletalMesh->SetSkeleton(BaseSkeleton);
+	USkeletalMesh* NewSkeletalMesh = NewObject<USkeletalMesh>();
+	//USkeletalMeshLODSettings* NewLODSettings = DuplicateObject(SourceLODSettings, NewSkeletalMesh);
+	
+	NewSkeletalMesh->SetRefSkeleton(BaseSkeleton->GetReferenceSkeleton());
+	NewSkeletalMesh->SetSkeleton(BaseSkeleton);
+	//NewSkeletalMesh->SetLODSettings(NewLODSettings);
 
 	GenerateSkeletalMesh(
-		SkeletalMesh,
+		NewSkeletalMesh,
 		Surfaces,
 		SurfacesMaterial,
 		BoneTransformOverrides);
-
+	
 	// We register the skeleton resource (which is not meant to be transient to
 	// the engine).
-	SkeletalMeshComponent->SetSkeletalMesh(SkeletalMesh);
+	SkeletalMeshComponent->bPauseAnims = true;
+	SkeletalMeshComponent->SetSkeletalMesh(NewSkeletalMesh, false);
+	//SkeletalMeshComponent->RefreshExternalMorphTargetWeights(true);
+
+	SkeletalMeshComponent->bPauseAnims = false;
 
 	check(SkeletalMeshComponent->RequiredBones.Num() != 0);
 	check(SkeletalMeshComponent->FillComponentSpaceTransformsRequiredBones.Num() != 0);
+
+	return NewSkeletalMesh;
 }
 
 bool FRuntimeSkeletalMeshGenerator::DecomposeSkeletalMesh(
@@ -763,7 +824,12 @@ bool FRuntimeSkeletalMeshGenerator::DecomposeSkeletalMesh(
 				BoneInfluenceIndex < RenderSection.MaxBoneInfluences;
 				BoneInfluenceIndex += 1)
 			{
+				const int32 BoneIndex = RenderData.SkinWeightVertexBuffer.GetBoneIndex(VertexIndex, BoneInfluenceIndex);
 				Surface.BoneInfluences[i][BoneInfluenceIndex].VertexIndex = i;
+				if (!RenderSection.BoneMap.IsValidIndex(BoneIndex))
+				{
+					continue;
+				}
 				Surface.BoneInfluences[i][BoneInfluenceIndex].BoneIndex =
 					RenderSection.BoneMap[RenderData.SkinWeightVertexBuffer.GetBoneIndex(VertexIndex, BoneInfluenceIndex)];
 				Surface.BoneInfluences[i][BoneInfluenceIndex].Weight =

--- a/Source/RuntimeSkeletalMeshGenerator/RuntimeSkeletalMeshGenerator.h
+++ b/Source/RuntimeSkeletalMeshGenerator/RuntimeSkeletalMeshGenerator.h
@@ -77,7 +77,7 @@ public: // ----------------------------------------------------------------- API
 	 * Update an existing the `SkeletalMeshComponent` for the given surfaces
 	 * optionally supply the transform override
 	 */
-	static USkeletalMesh* UpdateSkeletalMeshComponent(
+	static void UpdateSkeletalMeshComponent(
 		USkeletalMeshComponent* SkeletalMeshComponent,
 		USkeleton* BaseSkeleton,
 		const TArray<FMeshSurface>& Surfaces,

--- a/Source/RuntimeSkeletalMeshGenerator/RuntimeSkeletalMeshGenerator.h
+++ b/Source/RuntimeSkeletalMeshGenerator/RuntimeSkeletalMeshGenerator.h
@@ -23,9 +23,9 @@
  */
 struct RUNTIMESKELETALMESHGENERATOR_API FRawBoneInfluence
 {
-	float Weight;
-	int32 VertexIndex;
-	int32 BoneIndex;
+	float Weight = 0;
+	int32 VertexIndex = 0;
+	int32 BoneIndex = 0;
 };
 
 /**
@@ -79,7 +79,7 @@ public: // ----------------------------------------------------------------- API
 	 * Update an existing the `SkeletalMeshComponent` for the given surfaces
 	 * optionally supply the transform override
 	 */
-	static void UpdateSkeletalMeshComponent(
+	static USkeletalMesh* UpdateSkeletalMeshComponent(
 		USkeletalMeshComponent* SkeletalMeshComponent,
 		USkeleton* BaseSkeleton,
 		const TArray<FMeshSurface>& Surfaces,


### PR DESCRIPTION
Did a small test by passing in an existing skeletal mesh to DecomposeSkeletalMesh() then passing that to GenerateSkeletalMeshComponent(). It seems to successfully load the skeletal mesh but the material UVs are wrong. Not sure how to fix that.
```

USkeletalMeshComponent* UAssetTestSaver::GenerateSkeletalMeshComponent(AActor* Actor, USkeleton* BaseSkeleton, USkeletalMesh* SkeletalMesh) {
    TArray<FMeshSurface> OutSurfaces;                  // The out Surfaces data that compose the `USkeletalMesh`.
    TArray<int32> OutSurfacesVertexOffsets;            // The vertex offsets for each surface, relative to the passed `SkeletalMesh`: This is useful just in case you need to reconstruct the vertex index used on the `USkeletalMesh`.
    TArray<int32> OutSurfacesIndexOffsets;             // The index offsets for each surface, relative to the passed `SkeletalMesh`: This is useful just in case you need to reconstruct the vertex index used on the `USkeletalMesh`.
    TArray<UMaterialInterface*> OutSurfacesMaterial;   // The Materials used.

    FRuntimeSkeletalMeshGenerator::DecomposeSkeletalMesh(
        SkeletalMesh,
        OutSurfaces,
        OutSurfacesVertexOffsets,
        OutSurfacesIndexOffsets,
        OutSurfacesMaterial);

    return FRuntimeSkeletalMeshGenerator::GenerateSkeletalMeshComponent(
        Actor,
        BaseSkeleton,
        OutSurfaces,
        OutSurfacesMaterial);
}
```