### PR TITLE
Fix UVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-# This plugin is riddled with bugs
-Look at this project instead, it will probably serve your purposes:
-
-https://github.com/rdeioris/glTFRuntime?tab=readme-ov-file
-
-
 # This Fork fixes 5 major bugs in this plugin
 The original version of the plugin has an issue that causes it to completely trash the model being loaded into UE4/5, this bug is fixed here.
 And a second issue that cause animations to fail, this bug is fixed here.

--- a/Source/RuntimeSkeletalMeshGenerator/RuntimeSkeletalMeshGenerator.h
+++ b/Source/RuntimeSkeletalMeshGenerator/RuntimeSkeletalMeshGenerator.h
@@ -23,9 +23,9 @@
  */
 struct RUNTIMESKELETALMESHGENERATOR_API FRawBoneInfluence
 {
-	float Weight;
-	int32 VertexIndex;
-	int32 BoneIndex;
+	float Weight = 0;
+	int32 VertexIndex = 0;
+	int32 BoneIndex = 0;
 };
 
 /**
@@ -38,7 +38,7 @@ struct RUNTIMESKELETALMESHGENERATOR_API FMeshSurface
 	TArray<bool> FlipBinormalSigns;
 	TArray<FVector> Normals;
 	TArray<FColor> Colors;
-	TArray<TArray<FVector2D>> Uvs;
+	TArray<TArray<FVector2f>> Uvs;
 	TArray<TArray<FRawBoneInfluence>> BoneInfluences;
 	TArray<uint32> Indices;
 };


### PR DESCRIPTION
Fransferdy missed some lines to entirely fix UVs.

This is an example of the plugin working on UE5.4:
<img width="506" alt="{1C0F6130-A009-4D08-9C78-64E301AB341A}" src="https://github.com/user-attachments/assets/9fcec5dc-3e0a-490a-8bfe-adad163dc3e2">
In this example I extruded some vertices at realtime